### PR TITLE
Fix

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -5,5 +5,4 @@ export default defineBuildConfig({
 	failOnWarn: false,
 	declaration: true,
 	clean: true,
-	outDir: '.',
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,20 +1,17 @@
 {
-  "name": "test-util",
-  "version": "1.0.0",
+  "name": "bhide",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "test-util",
-      "version": "1.0.0",
+      "name": "bhide",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "execa": "^9.3.0",
         "fs-extra": "^11.2.0",
         "template-factory": "^0.1.3"
-      },
-      "bin": {
-        "test-util": "bin.mjs"
       },
       "devDependencies": {
         "@types/fs-extra": "^11.0.4",

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ const main = async () => {
 			{
 				name: 'SvelteKit',
 				// we have to pass it this way so that it resolves correctly in production
-				path: util.relative('templates/code', import.meta.url),
+				path: util.relative('../templates/code', import.meta.url),
 				flag: 'sveltekit',
 				prompts: [
 					{
@@ -29,7 +29,7 @@ const main = async () => {
 										kind: 'confirm',
 										message: 'Would you like to Install Tailwind CSS Framework',
 										yes: {
-											run: async ({ dir }): Promise<Prompt[]> => {
+											run: async (): Promise<Prompt[]> => {
 												return [
 													{
 														kind: 'select',
@@ -83,7 +83,7 @@ const main = async () => {
 						yes: {
 							run: async ({ dir }) => {
 								await execa({ cwd: dir })`npm install @supabase/supabase-js`;
-								let dbfile = fs.readFile('./src/db.ts', 'utf8', (err, data) => {
+								let dbfile = fs.readFile(util.relative('./db.ts', import.meta.url), 'utf8', (err, data) => {
 									if (err) {
 										console.error(err)
 										return
@@ -92,7 +92,7 @@ const main = async () => {
 									fs.writeFileSync(file, data);
 								});
 								let file = path.join(dir, '/.env');
-								let envCode = await fs.readFileSync('./src/envCode.txt');
+								let envCode = await fs.readFileSync(util.relative('./envcode.txt', import.meta.url));
 								fs.writeFileSync(file,envCode);
 							},
 							startMessage: 'Installing Supabase',


### PR DESCRIPTION
## Changes
- Changed so that now built files go to `/dist`
- Make sure to use `util.relative` to access any paths within your own projects (I made the corrections i found)

## Suggestions
- It may be nice to include a `template-files` directory for files that are not actual code in your project but instead just code to be copied for the template (make sure to ignore these files in compilation steps etc.)